### PR TITLE
Fix segfault and iterator error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bundle/
+vendor/
 *~
 *.bak
 *.o

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,1 @@
+std = "max+busted"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: 5bf6c09bfa1297d3692cadd621ef95f1284e33c0
+    hooks:
+    -   id: trailing-whitespace
+        files: \.(c|h|js|json|lua|md|py|sh|txt|yaml|yml)$
+    -   id: check-case-conflict
+    -   id: end-of-file-fixer
+-   repo: local
+    hooks:
+    -   id: travis-lint
+        name: Travis Lint
+        entry: bundle
+        language: system
+        files: ^\.travis\.yml$
+        args:
+        - exec
+        - travis
+        - lint
+        - --no-interactive
+        - --skip-version-check
+        - --skip-completion-check
+        - --exit-code
+    -   id: lua-check
+        name: Lua Check
+        entry: luacheck
+        language: system
+        files: \.(lua|rockspec)$
+    -   id: luarocks-lint
+        name: Luarocks Lint
+        entry: luarocks
+        language: system
+        files: \.(rockspec)$
+        args:
+        - --local
+        - lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# .travis.yaml
+
+language: python
+dist: trusty
+sudo: required
+
+env:
+  - LUA="lua=5.1"
+  - LUA="lua=5.2"
+  #- LUA="lua=5.3"
+  #- LUA="luajit=2.0"
+  #- LUA="luajit=2.1"
+
+before_install:
+  - sudo apt-get -qq update
+  - cat tests/slapd.debconf | sudo debconf-set-selections
+  - sudo apt-get install -y slapd ldap-utils libldap-dev
+  - pip install hererocks
+  - hererocks lua_install -r^ --$LUA
+  - source lua_install/bin/activate
+
+install:
+  - ldapadd -x -D cn=admin,dc=example,dc=com -w admin -f tests/test.ldif
+  #- luarocks install luacheck
+
+script:
+  #- luacheck *.lua spec
+  - luarocks make --local rockspecs/lualdap/lualdap-1.2.3-1.rockspec
+  - lua tests/test.lua localhost dc=example,dc=com cn=admin,dc=example,dc=com admin

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: required
 env:
   - LUA="lua=5.1"
   - LUA="lua=5.2"
-  #- LUA="lua=5.3"
+  - LUA="lua=5.3"
   #- LUA="luajit=2.0"
   #- LUA="luajit=2.1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+group :test do
+  gem 'travis'
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    backports (3.7.0)
+    ethon (0.10.1)
+      ffi (>= 1.3.0)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
+    ffi (1.9.18)
+    gh (0.15.1)
+      addressable (~> 2.4.0)
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (~> 2.9)
+      net-http-pipeline
+    highline (1.7.8)
+    json (2.0.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    travis (1.8.8)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    websocket (1.2.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  travis
+
+BUNDLED WITH
+   1.11.2

--- a/src/lualdap.c
+++ b/src/lualdap.c
@@ -1003,7 +1003,7 @@ static int lualdap_initialize (lua_State *L) {
 static int lualdap_open_simple (lua_State *L) {
 	ldap_pchar_t host = (ldap_pchar_t) luaL_checkstring (L, 1);
 	ldap_pchar_t who = (ldap_pchar_t) luaL_optstring (L, 2, NULL);
-	const char *password = luaL_optstring (L, 3, NULL);
+	const char *password = luaL_optstring (L, 3, "");
 	int use_tls = lua_toboolean (L, 4);
 	conn_data *conn = (conn_data *)lua_newuserdata (L, sizeof(conn_data));
 #if defined(LDAP_API_FEATURE_X_OPENLDAP) && LDAP_API_FEATURE_X_OPENLDAP >= 20300

--- a/src/lualdap.c
+++ b/src/lualdap.c
@@ -722,8 +722,6 @@ static int next_message (lua_State *L) {
 	int rc;
 	int ret;
 
-	luaL_checktype(L, 1, LUA_TTABLE);
-
 	lua_rawgeti (L, LUA_REGISTRYINDEX, search->conn);
 	conn = (conn_data *)lua_touserdata (L, -1); /* get connection */
 

--- a/tests/slapd.debconf
+++ b/tests/slapd.debconf
@@ -1,0 +1,6 @@
+slapd slapd/password1 password admin
+slapd slapd/password2 password admin
+slapd slapd/purge_database boolean true
+slapd slapd/domain string example.com
+slapd shared/organization string example.com
+

--- a/tests/test.ldif
+++ b/tests/test.ldif
@@ -1,0 +1,28 @@
+dn: ou=People,dc=example,dc=com
+objectClass: organizationalUnit
+ou: People
+
+dn: ou=Groups,dc=example,dc=com
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=miners,ou=Groups,dc=example,dc=com
+objectClass: posixGroup
+cn: miners
+gidNumber: 5000
+
+dn: uid=john,ou=People,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: john
+sn: Doe
+givenName: John
+cn: John Doe
+displayName: John Doe
+uidNumber: 10000
+gidNumber: 5000
+userPassword: johnldap
+gecos: John Doe
+loginShell: /bin/bash
+homeDirectory: /home/john


### PR DESCRIPTION
The current version 1.2.3 segfaults on calling `open_simple()`. You can see logs from tests (see #2) for all Lua versions [here](https://travis-ci.org/jirutka/lualdap/builds/210152047).

When I fixed it, another error has appeared, caused by 2867f1f76321fe3832d19ee309b80be0bccaba1d:

    tests/test.lua:175: bad argument #1 to 'iter' (table expected, got no value)

You can see logs [here](https://travis-ci.org/jirutka/lualdap/builds/210152789).

And finally logs from green builds with both #1 and #2 applied are [here](https://travis-ci.org/jirutka/lualdap/builds/210152235). As you can see, tests passes even on Lua 5.3, so you can remove the upper bound for Lua version in rockspec (currently there’s `lua >= 5.1, < 5.3`).

/cc @devurandom 